### PR TITLE
Fix exit code on error to prevent restart loops in Docker environments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,10 @@ const main = async () => {
     } catch (error) {
         client.logger.error(error as string);
         await client.destroy();
-        process.exit(1);
+        process.exit(0);
+        // Exit code 0 suggests a succesful run, however this is not the case here
+        // We have this so that environments who run this in docker with the flag --restart=unless-stopped
+        // will not keep restarting and cause a potential loop of restarts with incorrect credentials
     }
 };
 


### PR DESCRIPTION
Change the exit code to prevent Docker from restarting the process in error scenarios, avoiding potential restart loops with incorrect credentials.