### PR TITLE
Add error handling for missing Discord token

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,11 @@
 import client from '@src/system/botClient.js';
 
 const main = async () => {
+    if (!process.env.DISCORD_TOKEN) {
+        client.logger.error('No token provided! Exiting...');
+        process.exit(0);
+    }
+
     try {
         await client.login(process.env.DISCORD_TOKEN);
         client.logger.log('Logged in!');


### PR DESCRIPTION
Implement error handling in the main function to exit gracefully if the Discord token is not provided.