### PR TITLE
Add role button command for role assignment in guilds

### DIFF
--- a/src/commands/utilities/buttonrole.ts
+++ b/src/commands/utilities/buttonrole.ts
@@ -1,0 +1,160 @@
+import TextCommandBuilder from '@builders/gargoyleTextCommandBuilder.js';
+import GargoyleClient from '@classes/gargoyleClient.js';
+import GargoyleCommand from '@classes/gargoyleCommand.js';
+import GargoyleButtonBuilder from '@src/system/backend/builders/gargoyleButtonBuilder.js';
+import { GargoyleRoleSelectMenuBuilder } from '@src/system/backend/builders/gargoyleSelectMenuBuilders.js';
+import {
+    ActionRowBuilder,
+    AnySelectMenuInteraction,
+    ButtonInteraction,
+    ButtonStyle,
+    ChatInputCommandInteraction,
+    InteractionContextType,
+    Message,
+    SlashCommandBuilder,
+    TextChannel
+} from 'discord.js';
+
+export default class Ping extends GargoyleCommand {
+    public override category: string = 'utilities';
+    public override slashCommand = new SlashCommandBuilder()
+        .setName('rolebutton')
+        .setDescription('Create a button that gives a role')
+        .setContexts([InteractionContextType.Guild]);
+    public override textCommand = new TextCommandBuilder()
+        .setName('buttonrole')
+        .setDescription('Create a role button')
+        .addAlias('br')
+        .addAlias('rolebutton')
+        .addAlias('rb')
+        .setContexts([InteractionContextType.Guild]);
+
+    public override async executeSlashCommand(_client: GargoyleClient, interaction: ChatInputCommandInteraction) {
+        if (!interaction.memberPermissions?.has('ManageRoles')) {
+            await interaction.reply({ content: 'You do not have the required permissions to use this command.', ephemeral: true });
+            return;
+        }
+        await interaction.reply({
+            content: 'What role(s) would you like to give?',
+            ephemeral: true,
+            components: [
+                new ActionRowBuilder<GargoyleRoleSelectMenuBuilder>().addComponents(
+                    new GargoyleRoleSelectMenuBuilder(this, 'roles').setMaxValues(25).setMinValues(1).setPlaceholder('Select role(s) to give')
+                )
+            ]
+        });
+    }
+
+    public override async executeTextCommand(_client: GargoyleClient, message: Message) {
+        if (!message.member?.permissions?.has('ManageRoles')) {
+            await message.reply({ content: 'You do not have the required permissions to use this command.' });
+            return;
+        }
+        (message.channel as TextChannel).send({
+            content: 'What role(s) would you like to give?',
+            components: [
+                new ActionRowBuilder<GargoyleRoleSelectMenuBuilder>().addComponents(
+                    new GargoyleRoleSelectMenuBuilder(this, 'roles').setMaxValues(25).setMinValues(1).setPlaceholder('Select role(s) to give')
+                )
+            ]
+        });
+    }
+
+    public override async executeSelectMenuCommand(client: GargoyleClient, interaction: AnySelectMenuInteraction, ...args: string[]): Promise<void> {
+        if (interaction.channel === null) return;
+        if (interaction.isRoleSelectMenu()) {
+            if (args[0] === 'roles') {
+                const roles = interaction.values;
+                interaction.update({ content: 'Making the button message...', components: [] });
+
+                const member = await interaction.guild?.members.fetch(interaction.user.id);
+                if (!member) return;
+
+                const channel = (await client.channels.fetch(interaction.channel.id)) as TextChannel;
+                if (!channel) return;
+
+                const componentCollection: ActionRowBuilder<GargoyleButtonBuilder>[] = [];
+
+                // For every 5 roles create a new action row
+                let roleCount = 0;
+                let actionRow = new ActionRowBuilder<GargoyleButtonBuilder>();
+                for (const roleId of roles) {
+                    roleCount++;
+                    const role = await interaction.guild?.roles.fetch(roleId);
+                    if (!role) continue;
+
+                    if (role.position >= member?.roles.highest.position) {
+                        interaction.reply({
+                            content: `You cannot give yourself the role ${role.name} as it is higher than your highest role.`,
+                            ephemeral: true
+                        });
+                        return;
+                    }
+
+                    actionRow.addComponents(
+                        new GargoyleButtonBuilder(this, 'addrole', role?.id).setLabel(role?.name).setStyle(ButtonStyle.Secondary)
+                    );
+                    if (roleCount === 5) {
+                        roleCount = 0;
+                        componentCollection.push(actionRow);
+                        actionRow = new ActionRowBuilder<GargoyleButtonBuilder>();
+                    }
+                }
+                if (roleCount > 0) {
+                    componentCollection.push(actionRow);
+                }
+
+                channel.fetchWebhooks().then(async (webhooks) => {
+                    let webhook;
+
+                    if (webhooks.size === 0) {
+                        webhook = await channel.createWebhook({ name: 'Role Button', reason: 'Role Button webhook' });
+                    } else {
+                        webhook = webhooks.first();
+                    }
+
+                    webhook?.send({
+                        avatarURL: interaction.guild?.iconURL() || undefined,
+                        username: interaction.guild?.name || 'Role Button',
+                        components: componentCollection
+                    });
+                });
+            }
+        }
+    }
+
+    public override async executeButtonCommand(_client: GargoyleClient, interaction: ButtonInteraction, ...args: string[]): Promise<void> {
+        if (args[0] === 'addrole') {
+            const role = await interaction.guild?.roles.fetch(args[1]);
+            if (!role) return;
+
+            const member = await interaction.guild?.members.fetch(interaction.user.id);
+
+            if (member?.roles.cache.has(role.id)) {
+                await member?.roles
+                    .remove(role)
+                    .catch(() => {
+                        interaction.reply({
+                            content: `Failed to remove role ${role.name}, I may not have the correct permissions to take it away from you.`,
+                            ephemeral: true
+                        });
+                    })
+                    .then(() => {
+                        interaction.reply({ content: `Removed role ${role.name}`, ephemeral: true });
+                    });
+            } else {
+                await member?.roles
+                    .add(role)
+                    .catch(() => {
+                        interaction.reply({
+                            content: `Failed to add role ${role.name}, I may not have the correct permissions to give it to you.`,
+                            ephemeral: true
+                        });
+                    })
+                    .then(() => {
+                        interaction.reply({ content: `Added role ${role.name}`, ephemeral: true });
+                    });
+            }
+        }
+    }
+}

--- a/src/commands/utilities/dynvcs.ts
+++ b/src/commands/utilities/dynvcs.ts
@@ -93,7 +93,10 @@ export default class VoicechatCommand extends GargoyleCommand {
                     (channel as VoiceChannel).permissionOverwrites.edit(interaction.guild.id, { Connect: true, PrioritySpeaker: true });
                 });
 
-            interaction.reply({ content: `Created the dynamic vc, use \`/vc panel\` or \`${client.prefix}vc\` to get the vc panel!`, ephemeral: true });
+            interaction.reply({
+                content: `Created the dynamic vc, use \`/vc panel\` or \`${client.prefix}vc\` to get the vc panel!`,
+                ephemeral: true
+            });
         }
     }
 
@@ -102,7 +105,7 @@ export default class VoicechatCommand extends GargoyleCommand {
     }
 
     public override async executeButtonCommand(client: GargoyleClient, interaction: ButtonInteraction, ...args: string[]): Promise<void> {
-        if (args[0] !== "rename") await interaction.deferReply({ ephemeral: true });
+        if (args[0] !== 'rename') await interaction.deferReply({ ephemeral: true });
         if (!interaction.guildId || !interaction.user.id) return;
         if (client.user === null) return;
 
@@ -124,148 +127,148 @@ export default class VoicechatCommand extends GargoyleCommand {
         }
 
         switch (args[0]) {
-            case 'lock': {
-                client.logger.trace(`User ${interaction.user.username} locked/unlocked their vc.`);
-                // Lock  / Unlock the vc
-                if (
-                    vc.permissionOverwrites.resolve(interaction.guildId) &&
+        case 'lock': {
+            client.logger.trace(`User ${interaction.user.username} locked/unlocked their vc.`);
+            // Lock  / Unlock the vc
+            if (
+                vc.permissionOverwrites.resolve(interaction.guildId) &&
                     vc.permissionOverwrites.resolve(interaction.guildId)?.deny.has(PermissionFlagsBits.Connect)
-                ) {
-                    if (vc.parent && vc.parent.permissionOverwrites.resolve(interaction.guildId)) {
-                        if (vc.parent.permissionOverwrites.resolve(interaction.guildId)?.allow.has(PermissionFlagsBits.Connect)) {
-                            vc.permissionOverwrites.edit(interaction.guildId, { Connect: true });
-                        } else {
-                            vc.permissionOverwrites.edit(interaction.guildId, { Connect: null });
-                        }
-                    } else vc.permissionOverwrites.edit(interaction.guildId, { Connect: null });
+            ) {
+                if (vc.parent && vc.parent.permissionOverwrites.resolve(interaction.guildId)) {
+                    if (vc.parent.permissionOverwrites.resolve(interaction.guildId)?.allow.has(PermissionFlagsBits.Connect)) {
+                        vc.permissionOverwrites.edit(interaction.guildId, { Connect: true });
+                    } else {
+                        vc.permissionOverwrites.edit(interaction.guildId, { Connect: null });
+                    }
+                } else vc.permissionOverwrites.edit(interaction.guildId, { Connect: null });
 
-                    interaction.editReply({ content: 'Unlocked your vc!' });
-                } else {
-                    vc.permissionOverwrites.edit(interaction.guildId, { Connect: false });
-                    interaction.editReply({ content: 'Locked your vc!' });
-                }
-                break;
+                interaction.editReply({ content: 'Unlocked your vc!' });
+            } else {
+                vc.permissionOverwrites.edit(interaction.guildId, { Connect: false });
+                interaction.editReply({ content: 'Locked your vc!' });
             }
-            case 'hide': {
-                client.logger.trace(`User ${interaction.user.username} hid/unhid their vc.`);
-                // Hide  / Unlock the vc
-                if (
-                    vc.permissionOverwrites.resolve(interaction.guildId) &&
+            break;
+        }
+        case 'hide': {
+            client.logger.trace(`User ${interaction.user.username} hid/unhid their vc.`);
+            // Hide  / Unlock the vc
+            if (
+                vc.permissionOverwrites.resolve(interaction.guildId) &&
                     vc.permissionOverwrites.resolve(interaction.guildId)?.deny.has(PermissionFlagsBits.ViewChannel)
-                ) {
-                    if (vc.parent && vc.parent.permissionOverwrites.resolve(interaction.guildId)) {
-                        if (vc.parent.permissionOverwrites.resolve(interaction.guildId)?.allow.has(PermissionFlagsBits.ViewChannel)) {
-                            vc.permissionOverwrites.edit(interaction.guildId, { ViewChannel: true });
-                        } else {
-                            vc.permissionOverwrites.edit(interaction.guildId, { ViewChannel: null });
-                        }
-                    } else vc.permissionOverwrites.edit(interaction.guildId, { ViewChannel: null });
+            ) {
+                if (vc.parent && vc.parent.permissionOverwrites.resolve(interaction.guildId)) {
+                    if (vc.parent.permissionOverwrites.resolve(interaction.guildId)?.allow.has(PermissionFlagsBits.ViewChannel)) {
+                        vc.permissionOverwrites.edit(interaction.guildId, { ViewChannel: true });
+                    } else {
+                        vc.permissionOverwrites.edit(interaction.guildId, { ViewChannel: null });
+                    }
+                } else vc.permissionOverwrites.edit(interaction.guildId, { ViewChannel: null });
 
-                    interaction.editReply({ content: 'Unhid your vc!' });
-                } else {
-                    vc.permissionOverwrites.edit(interaction.guildId, { ViewChannel: false });
-                    interaction.editReply({ content: 'Hid your vc!' });
-                }
-                break;
+                interaction.editReply({ content: 'Unhid your vc!' });
+            } else {
+                vc.permissionOverwrites.edit(interaction.guildId, { ViewChannel: false });
+                interaction.editReply({ content: 'Hid your vc!' });
             }
-            case 'increase': {
-                client.logger.trace(`User ${interaction.user.username} increased the user limit of their vc.`);
-                // Increase the user limit
-                vc.edit({ userLimit: vc.userLimit + 1 });
-                interaction.editReply({ content: `Increased the user limit to ${vc.userLimit + 1}!` });
-                break;
-            }
-            case 'decrease': {
-                client.logger.trace(`User ${interaction.user.username} decreased the user limit of their vc.`);
-                // Decrease the user limit
+            break;
+        }
+        case 'increase': {
+            client.logger.trace(`User ${interaction.user.username} increased the user limit of their vc.`);
+            // Increase the user limit
+            vc.edit({ userLimit: vc.userLimit + 1 });
+            interaction.editReply({ content: `Increased the user limit to ${vc.userLimit + 1}!` });
+            break;
+        }
+        case 'decrease': {
+            client.logger.trace(`User ${interaction.user.username} decreased the user limit of their vc.`);
+            // Decrease the user limit
 
-                await vc.edit({ userLimit: vc.userLimit - 1 }).catch(() => { });
-                if (vc.userLimit !== 1 && vc.userLimit !== 0) {
-                    interaction.editReply({ content: `Decreased the user limit to ${vc.userLimit - 1}!` });
-                } else if (vc.userLimit === 1) {
-                    interaction.editReply({ content: 'Disabled the user limit!' });
-                } else {
-                    interaction.editReply({ content: 'The user limit is already at 0!' });
-                }
-                break;
+            await vc.edit({ userLimit: vc.userLimit - 1 }).catch(() => {});
+            if (vc.userLimit !== 1 && vc.userLimit !== 0) {
+                interaction.editReply({ content: `Decreased the user limit to ${vc.userLimit - 1}!` });
+            } else if (vc.userLimit === 1) {
+                interaction.editReply({ content: 'Disabled the user limit!' });
+            } else {
+                interaction.editReply({ content: 'The user limit is already at 0!' });
             }
-            case 'ban': {
-                client.logger.trace(`User ${interaction.user.username} banned a user from their vc.`);
-                // Send a select menu with all the members
-                interaction.editReply({
-                    components: [
-                        new ActionRowBuilder<GargoyleUserSelectMenuBuilder>().addComponents(
-                            new GargoyleUserSelectMenuBuilder(this, 'ban').setPlaceholder('Select member(s) to ban.').setMaxValues(1).setMinValues(1)
-                        )
-                    ]
-                });
-                break;
-            }
-            case 'invite': {
-                client.logger.trace(`User ${interaction.user.username} invited a user to their vc.`);
-                // Send a select menu with all the members
-                interaction.editReply({
-                    components: [
-                        new ActionRowBuilder<GargoyleUserSelectMenuBuilder>().addComponents(
-                            new GargoyleUserSelectMenuBuilder(this, 'invite')
-                                .setPlaceholder('Select member(s) to invite.')
-                                .setMaxValues(1)
-                                .setMinValues(1)
-                        )
-                    ]
-                });
-                break;
-            }
-            case 'rename': {
-                client.logger.trace(`User ${interaction.user.username} tried to rename their vc.`);
-                // Send a modal with a text input to choose the name.
-                const maxLength = 25; // - client.db.guilds.get(interaction.guild.id).dynvcs.prefix.length;
-                interaction.showModal(
-                    new GargoyleModalBuilder(this, 'rename')
-                        .setTitle('Rename the VC')
-                        .setComponents(
-                            new ActionRowBuilder<ModalActionRowComponentBuilder>().setComponents(
-                                new TextInputBuilder()
-                                    .setCustomId('name')
-                                    .setPlaceholder('Cool VC!')
-                                    .setMaxLength(maxLength)
-                                    .setMinLength(1)
-                                    .setRequired(true)
-                                    .setLabel('New name for the VC.')
-                                    .setStyle(TextInputStyle.Short)
-                            )
-                        )
-                );
-                break;
-            }
-            case 'claim': {
-                client.logger.trace(`User ${interaction.user.username} claimed a vc.`);
-                // Claim the vc
-                // Check if any of the members in the vc are the owner
-                let owner;
-
-                vc.members.forEach((member) => {
-                    if (
-                        vc.permissionOverwrites.resolve(member.id) &&
-                        vc.permissionOverwrites.resolve(member.id)?.allow.has(PermissionFlagsBits.AddReactions)
+            break;
+        }
+        case 'ban': {
+            client.logger.trace(`User ${interaction.user.username} banned a user from their vc.`);
+            // Send a select menu with all the members
+            interaction.editReply({
+                components: [
+                    new ActionRowBuilder<GargoyleUserSelectMenuBuilder>().addComponents(
+                        new GargoyleUserSelectMenuBuilder(this, 'ban').setPlaceholder('Select member(s) to ban.').setMaxValues(1).setMinValues(1)
                     )
-                        owner = member;
-                });
+                ]
+            });
+            break;
+        }
+        case 'invite': {
+            client.logger.trace(`User ${interaction.user.username} invited a user to their vc.`);
+            // Send a select menu with all the members
+            interaction.editReply({
+                components: [
+                    new ActionRowBuilder<GargoyleUserSelectMenuBuilder>().addComponents(
+                        new GargoyleUserSelectMenuBuilder(this, 'invite')
+                            .setPlaceholder('Select member(s) to invite.')
+                            .setMaxValues(1)
+                            .setMinValues(1)
+                    )
+                ]
+            });
+            break;
+        }
+        case 'rename': {
+            client.logger.trace(`User ${interaction.user.username} tried to rename their vc.`);
+            // Send a modal with a text input to choose the name.
+            const maxLength = 25; // - client.db.guilds.get(interaction.guild.id).dynvcs.prefix.length;
+            interaction.showModal(
+                new GargoyleModalBuilder(this, 'rename')
+                    .setTitle('Rename the VC')
+                    .setComponents(
+                        new ActionRowBuilder<ModalActionRowComponentBuilder>().setComponents(
+                            new TextInputBuilder()
+                                .setCustomId('name')
+                                .setPlaceholder('Cool VC!')
+                                .setMaxLength(maxLength)
+                                .setMinLength(1)
+                                .setRequired(true)
+                                .setLabel('New name for the VC.')
+                                .setStyle(TextInputStyle.Short)
+                        )
+                    )
+            );
+            break;
+        }
+        case 'claim': {
+            client.logger.trace(`User ${interaction.user.username} claimed a vc.`);
+            // Claim the vc
+            // Check if any of the members in the vc are the owner
+            let owner;
 
-                if (owner) {
-                    interaction.editReply({ content: 'The owner is still in the vc!' });
-                    return;
-                }
+            vc.members.forEach((member) => {
+                if (
+                    vc.permissionOverwrites.resolve(member.id) &&
+                        vc.permissionOverwrites.resolve(member.id)?.allow.has(PermissionFlagsBits.AddReactions)
+                )
+                    owner = member;
+            });
 
-                // Claim the vc
-                vc.permissionOverwrites.edit(interaction.user.id, {
-                    AddReactions: true,
-                    Connect: true
-                });
-
-                interaction.editReply({ content: 'You have claimed the vc!' });
-                break;
+            if (owner) {
+                interaction.editReply({ content: 'The owner is still in the vc!' });
+                return;
             }
+
+            // Claim the vc
+            vc.permissionOverwrites.edit(interaction.user.id, {
+                AddReactions: true,
+                Connect: true
+            });
+
+            interaction.editReply({ content: 'You have claimed the vc!' });
+            break;
+        }
         }
         interaction.message.edit(this.panelMessage as MessageEditOptions);
     }
@@ -290,17 +293,17 @@ export default class VoicechatCommand extends GargoyleCommand {
         }
 
         switch (args[0]) {
-            case 'rename': {
-                vc.edit({ name: interaction.fields.getTextInputValue('name') })
-                    .catch(() => {
-                        interaction.reply({ content: 'Failed to rename the vc!', ephemeral: true });
-                    })
-                    .then(() => {
-                        interaction.reply({ content: `Renamed the vc to ${interaction.fields.getTextInputValue('name')}`, ephemeral: true });
-                    });
+        case 'rename': {
+            vc.edit({ name: interaction.fields.getTextInputValue('name') })
+                .catch(() => {
+                    interaction.reply({ content: 'Failed to rename the vc!', ephemeral: true });
+                })
+                .then(() => {
+                    interaction.reply({ content: `Renamed the vc to ${interaction.fields.getTextInputValue('name')}`, ephemeral: true });
+                });
 
-                break;
-            }
+            break;
+        }
         }
     }
 
@@ -325,31 +328,31 @@ export default class VoicechatCommand extends GargoyleCommand {
         }
 
         switch (args[0]) {
-            case 'ban': {
-                interaction.values.forEach((value) => {
-                    if (!interaction.guildId) return;
+        case 'ban': {
+            interaction.values.forEach((value) => {
+                if (!interaction.guildId) return;
 
-                    const member = client.guilds.cache.get(interaction.guildId)?.members.cache.get(value);
-                    if (member) {
-                        vc.permissionOverwrites.edit(member.id, { Connect: false });
-                        interaction.reply({ content: `Banned ${member.user.tag} from the vc!`, ephemeral: true });
-                        vc.members.get(member.id)?.voice.setChannel(null);
-                    }
-                });
-                break;
-            }
-            case 'invite': {
-                interaction.values.forEach((value) => {
-                    if (!interaction.guildId) return;
+                const member = client.guilds.cache.get(interaction.guildId)?.members.cache.get(value);
+                if (member) {
+                    vc.permissionOverwrites.edit(member.id, { Connect: false });
+                    interaction.reply({ content: `Banned ${member.user.tag} from the vc!`, ephemeral: true });
+                    vc.members.get(member.id)?.voice.setChannel(null);
+                }
+            });
+            break;
+        }
+        case 'invite': {
+            interaction.values.forEach((value) => {
+                if (!interaction.guildId) return;
 
-                    const member = client.guilds.cache.get(interaction.guildId)?.members.cache.get(value);
-                    if (member) {
-                        vc.permissionOverwrites.edit(member.id, { Connect: true });
-                        interaction.reply({ content: `Invited ${member.user.tag} to the vc!`, ephemeral: true });
-                    }
-                });
-                break;
-            }
+                const member = client.guilds.cache.get(interaction.guildId)?.members.cache.get(value);
+                if (member) {
+                    vc.permissionOverwrites.edit(member.id, { Connect: true });
+                    interaction.reply({ content: `Invited ${member.user.tag} to the vc!`, ephemeral: true });
+                }
+            });
+            break;
+        }
         }
     }
 
@@ -401,7 +404,7 @@ class VoiceUpdate extends GargoyleEvent {
 
                 if (channel) {
                     // Drag the user to the channel they own
-                    newState.member.voice.setChannel(channel as VoiceChannel).catch(() => { });
+                    newState.member.voice.setChannel(channel as VoiceChannel).catch(() => {});
                 } else {
                     // Create a new channel for the user with the same permissions as the
                     // category if the channel they joined has a category
@@ -424,14 +427,14 @@ class VoiceUpdate extends GargoyleEvent {
                                 ?.send(
                                     `<@!${newState.member.id}> I don't have permission to create a channel in the category you are in. Please make sure I have the correct permissions and try again.\nContact your server administrator if you need help.`
                                 )
-                                .catch(() => { });
+                                .catch(() => {});
 
                             newState.guild.fetchOwner().then((owner) => {
                                 owner
                                     .send(
                                         `I don't have permission to send messages in any channel in ${newState.guild.name}. Please give me permission to send messages in a channel and try again.`
                                     )
-                                    .catch(() => { });
+                                    .catch(() => {});
                             });
 
                             client.logger.warning(`${newState.guild.name}, incorrectly configured permissions.`);
@@ -447,11 +450,11 @@ class VoiceUpdate extends GargoyleEvent {
                                             AddReactions: true,
                                             Connect: true
                                         })
-                                        .catch(() => { });
-                                    channel.permissionOverwrites.create(oldState.client.user.id, { AddReactions: true }).catch(() => { });
+                                        .catch(() => {});
+                                    channel.permissionOverwrites.create(oldState.client.user.id, { AddReactions: true }).catch(() => {});
 
                                     // Move the user to the channel
-                                    if (newState.member) newState.member.voice.setChannel(channel).catch(() => { });
+                                    if (newState.member) newState.member.voice.setChannel(channel).catch(() => {});
                                 })
                                 .catch(() => {
                                     channel.permissionOverwrites
@@ -459,11 +462,11 @@ class VoiceUpdate extends GargoyleEvent {
                                             AddReactions: true,
                                             Connect: true
                                         })
-                                        .catch(() => { });
-                                    channel.permissionOverwrites.create(oldState.client.user.id, { AddReactions: true }).catch(() => { });
+                                        .catch(() => {});
+                                    channel.permissionOverwrites.create(oldState.client.user.id, { AddReactions: true }).catch(() => {});
 
                                     // Move the user to the channel
-                                    if (newState.member) newState.member.voice.setChannel(channel).catch(() => { });
+                                    if (newState.member) newState.member.voice.setChannel(channel).catch(() => {});
                                 });
                         });
                 }
@@ -479,7 +482,7 @@ class VoiceUpdate extends GargoyleEvent {
                     channel.members.size === 0
                 ) {
                     // Delete the channel
-                    channel.delete().catch(() => { });
+                    channel.delete().catch(() => {});
                 }
             });
         }


### PR DESCRIPTION
Introduce a command that allows users to create a button for role assignment within guilds, enhancing role management capabilities. The command checks for necessary permissions and facilitates the selection of multiple roles.