### PR TITLE
Refactor command deletion logic in handlers for clarity and consistency

### DIFF
--- a/src/system/backend/events/commands/handlers/contextCommandHandler.ts
+++ b/src/system/backend/events/commands/handlers/contextCommandHandler.ts
@@ -30,10 +30,9 @@ export default class ContextCommandHandler extends GargoyleEvent {
                 });
 
 
-            if (interaction.guild?.commands.cache.has(interaction.commandName)) {
-                client.logger.warning(`Command not found: ${interaction.commandName}`);
-                interaction.guild.commands.cache.get(interaction.commandName)?.delete();
-            }
+            client.logger.warning(`Command not found: ${interaction.commandName}, deleting command.`);
+            interaction.command?.delete();
+
         } else {
             command.executeContextMenuCommand(client, interaction);
             return client.logger.trace(`${interaction.user} used the ${interaction.commandName} context command.`);

--- a/src/system/backend/events/commands/handlers/slashCommandHandler.ts
+++ b/src/system/backend/events/commands/handlers/slashCommandHandler.ts
@@ -22,10 +22,9 @@ export default class SlashCommandHandler extends GargoyleEvent {
                 }, 5000);
             });
 
-            if (interaction.guild?.commands.cache.has(interaction.commandName)) {
-                client.logger.warning(`Command not found: ${interaction.commandName}`);
-                interaction.guild.commands.cache.get(interaction.commandName)?.delete();
-            }
+            client.logger.warning(`Command not found: ${interaction.commandName}, deleting command.`);
+            interaction.command?.delete();
+
         } else {
             command.executeSlashCommand(client, interaction);
             return client.logger.trace(`${interaction.user} used the ${interaction.commandName} command.`);


### PR DESCRIPTION
Improve the clarity and consistency of command deletion logic in both context and slash command handlers. This change simplifies the deletion process when a command is not found.