### PR TITLE
Refactor server command to group subcommands under 'send'

### DIFF
--- a/src/commands/utilities/server.ts
+++ b/src/commands/utilities/server.ts
@@ -25,12 +25,17 @@ export default class Server extends GargoyleCommand {
         .setName('server')
         .setDescription('Server / community commands')
         .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
-        .addSubcommand((subcommand) => subcommand.setName('message').setDescription('Send a message as the server'))
-        .addSubcommand((subcommand) =>
-            subcommand
-                .setName('attachment')
-                .setDescription('Send an attachment as the server')
-                .addAttachmentOption((option) => option.setName('attachment').setDescription('Attachment to send').setRequired(true))
+        .addSubcommandGroup((subcommandGroup) =>
+            subcommandGroup
+                .setName('send')
+                .setDescription('Send things as the server')
+                .addSubcommand((subcommand) => subcommand.setName('message').setDescription('Send a message as the server'))
+                .addSubcommand((subcommand) =>
+                    subcommand
+                        .setName('attachment')
+                        .setDescription('Send an attachment as the server')
+                        .addAttachmentOption((option) => option.setName('attachment').setDescription('Attachment to send').setRequired(true))
+                )
         )
         .setContexts([InteractionContextType.Guild]) as SlashCommandBuilder;
     public override contextCommands = [


### PR DESCRIPTION
Organize server command subcommands into a 'send' group for better structure and clarity.