### PR TITLE
Enhance magic 8ball command to include user question in response

### DIFF
--- a/src/commands/fun/fun.ts
+++ b/src/commands/fun/fun.ts
@@ -482,5 +482,11 @@ function eightBall(interaction: ChatInputCommandInteraction): Promise<Interactio
         'Very doubtful.'
     ];
 
-    return interaction.reply({ embeds: [new GargoyleEmbedBuilder().setDescription(responses[Math.floor(Math.random() * responses.length)])] });
+    return interaction.reply({
+        embeds: [
+            new GargoyleEmbedBuilder().setDescription(
+                `${interaction.options.getString('question', true)}\n${responses[Math.floor(Math.random() * responses.length)]}`
+            )
+        ]
+    });
 }


### PR DESCRIPTION
Incorporate the user's question into the response of the magic 8ball command, providing a more personalized interaction.