### PR TITLE
Remove 'hide' option from voicechat panel command for simplification

### DIFF
--- a/src/commands/utilities/dynvcs.ts
+++ b/src/commands/utilities/dynvcs.ts
@@ -38,12 +38,7 @@ export default class VoicechatCommand extends GargoyleCommand {
         .setName('vc')
         .setDescription('Voicechat related commands.')
         .setContexts([InteractionContextType.Guild])
-        .addSubcommand((subcommand) =>
-            subcommand
-                .setName('panel')
-                .setDescription('Get the voicechat panel')
-                .addBooleanOption((option) => option.setName('hide').setDescription('Hide who issued the command').setRequired(false))
-        )
+        .addSubcommand((subcommand) => subcommand.setName('panel').setDescription('Get the voicechat panel'))
         .addSubcommand((subcommand) =>
             subcommand
                 .setName('create')
@@ -66,10 +61,8 @@ export default class VoicechatCommand extends GargoyleCommand {
 
     public override async executeSlashCommand(client: GargoyleClient, interaction: ChatInputCommandInteraction) {
         if (interaction.options.getSubcommand() === 'panel') {
-            if (interaction.options.getBoolean('hide')) {
-                interaction.reply({ content: 'Sending the panel!', flags: MessageFlags.Ephemeral });
-                (interaction.channel as TextChannel).send(this.panelMessage as MessageCreateOptions);
-            } else interaction.reply(this.panelMessage as InteractionReplyOptions);
+            interaction.reply({ content: 'Sending the panel!', flags: MessageFlags.Ephemeral });
+            (interaction.channel as TextChannel).send(this.panelMessage as MessageCreateOptions);
         } else if (interaction.options.getSubcommand() === 'create') {
             if (!interaction.guild) return;
             if (!client.user) return;


### PR DESCRIPTION
Eliminate the 'hide' option from the voicechat panel command to streamline the command's functionality.