### PR TITLE
Enhance Entropy command functionality by removing temporary invite links

### DIFF
--- a/src/commands/entropy/apply.ts
+++ b/src/commands/entropy/apply.ts
@@ -130,7 +130,6 @@ export default class Entropy extends GargoyleCommand {
             await interaction.deferReply({ flags: MessageFlags.Ephemeral });
             const inviteLink = await (interaction.channel as TextChannel)
                 .createInvite({
-                    temporary: true,
                     maxAge: 1 * 60 * 60 * 24 * 7,
                     maxUses: 1,
                     unique: true,


### PR DESCRIPTION
Improve the Entropy command by eliminating the creation of temporary invite links, enhancing overall functionality.