### PR TITLE
Fix incorrect permission overrides in voice channel creation

### DIFF
--- a/src/commands/utilities/dynvcs.ts
+++ b/src/commands/utilities/dynvcs.ts
@@ -94,10 +94,13 @@ export default class VoicechatCommand extends GargoyleCommand {
                     console.log(channel?.toJSON());
                     if (!channel) return;
                     if (!interaction.guild) return;
+                    if(!client.user) return;
 
-                    (channel as VoiceChannel).permissionOverwrites.edit(interaction.guild.id, { Connect: true, PrioritySpeaker: true, UseExternalStickers: true }).then(() => {
-                        interaction.editReply({ content: 'Created the dynamic vc, use `/vc panel` or `/vc` to get the vc panel!' });
-                    });
+                    (channel as VoiceChannel).permissionOverwrites
+                        .edit(client.user.id, { Connect: true, PrioritySpeaker: true })
+                        .then(() => {
+                            interaction.editReply({ content: 'Created the dynamic vc, use `/vc panel` or `/vc` to get the vc panel!' });
+                        });
                 });
         }
     }


### PR DESCRIPTION
Adjust permission overrides to correctly reference the client user, ensuring proper permissions are set for dynamic voice channels.