### PR TITLE
Refactor Entropy command and increase cooldown duration in RolePrefix event

### DIFF
--- a/src/commands/entropy/apply.ts
+++ b/src/commands/entropy/apply.ts
@@ -326,7 +326,7 @@ class RolePrefix extends GargoyleEvent {
     public async execute(_client: GargoyleClient, member: GuildMember): Promise<void> {
         if (member.guild.id !== '1009048008857493624') return;
 
-        if (this.lastChanged.has(member.id) && Date.now() - this.lastChanged.get(member.id)! < 5000) return;
+        if (this.lastChanged.has(member.id) && Date.now() - this.lastChanged.get(member.id)! < 10000) return;
 
         const updatedMember = await member.fetch(true);
         let namePrefix = '[';


### PR DESCRIPTION
Refactor the Entropy command to enhance member count retrieval and voice activity calculation. Increase the cooldown duration in the RolePrefix event to 10 seconds to prevent rapid updates.